### PR TITLE
Add report_fields_where_declared option

### DIFF
--- a/src/config/packages/doctrine.yaml
+++ b/src/config/packages/doctrine.yaml
@@ -5,6 +5,7 @@ doctrine:
     auto_generate_proxy_classes: true
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
+    report_fields_where_declared: true
     mappings:
       App:
         is_bundle: false


### PR DESCRIPTION
The `report_fields_where_declared` option has been added to fix the deprecated alert